### PR TITLE
[Events] Fix null reference

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Player/ChangingItemEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/ChangingItemEventArgs.cs
@@ -46,7 +46,7 @@ namespace Exiled.Events.EventArgs.Player
             get => newItem;
             set
             {
-                if (!Player.Inventory.UserInventory.Items.TryGetValue(value.Serial, out _))
+                if (value != null && !Player.Inventory.UserInventory.Items.TryGetValue(value.Serial, out _))
                     throw new InvalidOperationException("ev.NewItem cannot be set to an item they do not have.");
 
                 newItem = value;


### PR DESCRIPTION
- Fixed `Healed` event when `player is null`, example error:
  ```
  NullReferenceException: Object reference not set to an instance of an object
  Exiled.Events.EventArgs.Player.HealedEventArgs..ctor (Exiled.API.Features.Player player, System.Single lastAmount) (at <f4c00fd0d7e8475ab3c3400f59529cfe>:0)
  (wrapper dynamic-method) PlayerStatsSystem.HealthStat.PlayerStatsSystem.HealthStat.ServerHeal_Patch0(PlayerStatsSystem.HealthStat,single)
  (wrapper dynamic-method) InventorySystem.Items.Usables.Medkit.InventorySystem.Items.Usables.Medkit.OnEffectsActivated_Patch1(InventorySystem.Items.Usables.Medkit)
  InventorySystem.Items.Usables.Consumable.ActivateEffects () (at <e1b23ebe5ae54d29b01902bb36299308>:0)
  InventorySystem.Items.Usables.Consumable.ServerOnUsingCompleted () (at <e1b23ebe5ae54d29b01902bb36299308>:0)
  Exiled.API.Features.Player.UseItem (Exiled.API.Features.Items.Item item) (at <dac206d55b9b4093b9ec1ae7d0df2a04>:0)
  ```
  actually 90% thats just my skill issue with delays/npcs, in normal cases player wont be null, but anyway 
- Fixed `ChangingItemEventArgs` error while setting `Item` to `null` (event patch handle that, we just aborted that functional with that `value::Serial` check a long time ago😭), error example:
  ```
  Method "OnChangingItem" of the class "SomePluginName.EventHandlers" caused an exception when handling the event "Exiled.Events.Features.Event`1[[Exiled.Events.EventArgs.Player.ChangingItemEventArgs, Exiled.Events, Version=8.11.0.0, Culture=neutral, PublicKeyToken=null]]"
  System.NullReferenceException: Object reference not set to an instance of an object
    at Exiled.Events.EventArgs.Player.ChangingItemEventArgs.set_Item (Exiled.API.Features.Items.Item value) [0x0000b] in <f4c00fd0d7e8475ab3c3400f59529cfe>:0 
    at BetterDisarm.EventHandlers.OnChangingItem (Exiled.Events.EventArgs.Player.ChangingItemEventArgs ev) [0x0002d] in <2b3f6cc3ded64b19862158fad6bd02a6>:0 
    at Exiled.Events.Features.Event`1[T].InvokeNormal (T arg) [0x00028] in <f4c00fd0d7e8475ab3c3400f59529cfe>:0 
  ```